### PR TITLE
Add FastAPI backend for comparing store prices across areas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.venv/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# Deal Finder
+
+A lightweight FastAPI application that showcases how to compare product prices across multiple stores in an area. The service returns the cheapest price for every product along with the store that offers it.
+
+## Features
+
+- List supported areas with pricing data.
+- Retrieve all products for an area and highlight the lowest price for each one.
+- Query a specific product in an area to discover the cheapest store.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.10+
+- `pip`
+
+### Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Running the API
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Visit `http://127.0.0.1:8000/docs` to interact with the automatically generated Swagger UI.
+
+### Running Tests
+
+```bash
+pytest
+```
+
+## Extending
+
+The demo uses static in-memory data located in `app/data.py`. Replace this with calls to a database or external APIs to integrate real store pricing information.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,5 @@
+"""Application package for Deal Finder demo."""
+
+from . import services  # re-export for convenience
+
+__all__ = ["services"]

--- a/app/data.py
+++ b/app/data.py
@@ -1,0 +1,89 @@
+"""Static data store for product prices across areas and stores."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass(frozen=True)
+class StorePrice:
+    """Represents the price of a product in a specific store."""
+
+    store_name: str
+    price: float
+
+
+@dataclass(frozen=True)
+class ProductListing:
+    """Represents a product available in an area with prices from different stores."""
+
+    product_id: str
+    name: str
+    category: str
+    prices: List[StorePrice]
+
+
+# Demo dataset mimicking scraped price data grouped by area.
+# In a real application these would likely come from a database or API.
+AREAS: Dict[str, List[ProductListing]] = {
+    "downtown": [
+        ProductListing(
+            product_id="coffee-beans-1kg",
+            name="Premium Coffee Beans 1kg",
+            category="Grocery",
+            prices=[
+                StorePrice(store_name="Bean Palace", price=17.5),
+                StorePrice(store_name="SuperMart Central", price=16.99),
+                StorePrice(store_name="Budget Grocers", price=15.75),
+            ],
+        ),
+        ProductListing(
+            product_id="almond-milk-1l",
+            name="Organic Almond Milk 1L",
+            category="Dairy Alternatives",
+            prices=[
+                StorePrice(store_name="SuperMart Central", price=4.69),
+                StorePrice(store_name="Budget Grocers", price=3.99),
+            ],
+        ),
+        ProductListing(
+            product_id="dish-soap-500ml",
+            name="Eco Dish Soap 500ml",
+            category="Household",
+            prices=[
+                StorePrice(store_name="HomeEssentials", price=2.5),
+                StorePrice(store_name="Budget Grocers", price=2.19),
+            ],
+        ),
+    ],
+    "uptown": [
+        ProductListing(
+            product_id="coffee-beans-1kg",
+            name="Premium Coffee Beans 1kg",
+            category="Grocery",
+            prices=[
+                StorePrice(store_name="Cafe Collective", price=18.0),
+                StorePrice(store_name="Uptown Organics", price=17.25),
+            ],
+        ),
+        ProductListing(
+            product_id="oat-milk-1l",
+            name="Oat Milk 1L",
+            category="Dairy Alternatives",
+            prices=[
+                StorePrice(store_name="Uptown Organics", price=4.5),
+                StorePrice(store_name="Healthy Harvest", price=4.35),
+            ],
+        ),
+        ProductListing(
+            product_id="granola-500g",
+            name="Crunchy Granola 500g",
+            category="Grocery",
+            prices=[
+                StorePrice(store_name="Healthy Harvest", price=5.95),
+                StorePrice(store_name="SuperMart Uptown", price=5.5),
+                StorePrice(store_name="Uptown Organics", price=5.75),
+            ],
+        ),
+    ],
+}

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,39 @@
+"""FastAPI application exposing product price comparisons across stores."""
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+
+from .services import AreaNotFoundError, find_product, get_available_areas, summarize_cheapest_products
+
+app = FastAPI(title="Deal Finder", description="Compare store prices per area", version="0.1.0")
+
+
+@app.get("/areas")
+def list_areas() -> dict:
+    """Return available areas for which product data exists."""
+
+    return {"areas": get_available_areas()}
+
+
+@app.get("/areas/{area}/products")
+def get_products(area: str) -> dict:
+    """Return products in an area with their cheapest price information."""
+
+    try:
+        products = summarize_cheapest_products(area)
+    except AreaNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return {"area": area.lower(), "products": products}
+
+
+@app.get("/areas/{area}/products/{product_id}")
+def get_product(area: str, product_id: str) -> dict:
+    """Return cheapest price details for a specific product in an area."""
+
+    try:
+        product = find_product(area, product_id)
+    except AreaNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    if product is None:
+        raise HTTPException(status_code=404, detail=f"Product '{product_id}' not found in area '{area}'")
+    return product

--- a/app/services.py
+++ b/app/services.py
@@ -1,0 +1,79 @@
+"""Business logic for aggregating product prices across stores."""
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Dict, Iterable, List, Optional
+
+from .data import AREAS, ProductListing, StorePrice
+
+
+class AreaNotFoundError(KeyError):
+    """Raised when an area is not available in the dataset."""
+
+
+def get_available_areas() -> List[str]:
+    """Return the list of available areas that contain store data."""
+
+    return sorted(AREAS.keys())
+
+
+def _cheapest_price(prices: Iterable[StorePrice]) -> StorePrice:
+    try:
+        return min(prices, key=lambda price: price.price)
+    except ValueError as exc:
+        raise ValueError("Cannot determine cheapest price from an empty list") from exc
+
+
+def get_products_for_area(area: str) -> List[ProductListing]:
+    """Retrieve all product listings for a given area.
+
+    Args:
+        area: Area identifier.
+
+    Raises:
+        AreaNotFoundError: If the area is not known.
+    """
+
+    try:
+        return AREAS[area.lower()]
+    except KeyError as exc:
+        raise AreaNotFoundError(f"Unknown area: {area}") from exc
+
+
+def summarize_cheapest_products(area: str) -> List[Dict[str, object]]:
+    """Return summary data for the cheapest price of each product in an area."""
+
+    listings = get_products_for_area(area)
+
+    summary: List[Dict[str, object]] = []
+    for listing in listings:
+        cheapest = _cheapest_price(listing.prices)
+        summary.append(
+            {
+                "product_id": listing.product_id,
+                "name": listing.name,
+                "category": listing.category,
+                "cheapest_price": cheapest.price,
+                "cheapest_store": cheapest.store_name,
+                "stores": [asdict(price) for price in listing.prices],
+            }
+        )
+    return summary
+
+
+def find_product(area: str, product_id: str) -> Optional[Dict[str, object]]:
+    """Find a specific product in an area and return its cheapest price summary."""
+
+    listings = get_products_for_area(area)
+    for listing in listings:
+        if listing.product_id == product_id:
+            cheapest = _cheapest_price(listing.prices)
+            return {
+                "product_id": listing.product_id,
+                "name": listing.name,
+                "category": listing.category,
+                "cheapest_price": cheapest.price,
+                "cheapest_store": cheapest.store_name,
+                "stores": [asdict(price) for price in listing.prices],
+            }
+    return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.110.0
+uvicorn==0.29.0
+pytest==8.1.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,34 @@
+from app import services
+
+
+def test_get_available_areas_sorted():
+    areas = services.get_available_areas()
+    assert areas == sorted(areas)
+
+
+def test_summarize_cheapest_products_returns_expected_shape():
+    summary = services.summarize_cheapest_products("downtown")
+    assert summary, "Expected at least one product"
+    first = summary[0]
+    assert {"product_id", "name", "category", "cheapest_price", "cheapest_store", "stores"} <= first.keys()
+
+
+def test_find_product_returns_cheapest_details():
+    product = services.find_product("downtown", "almond-milk-1l")
+    assert product is not None
+    assert product["cheapest_store"] == "Budget Grocers"
+    assert product["cheapest_price"] == 3.99
+
+
+def test_find_product_missing_returns_none():
+    product = services.find_product("downtown", "non-existent")
+    assert product is None
+
+
+def test_unknown_area_raises():
+    try:
+        services.get_products_for_area("unknown")
+    except services.AreaNotFoundError as exc:
+        assert "Unknown area" in str(exc)
+    else:
+        raise AssertionError("Expected AreaNotFoundError for unknown area")


### PR DESCRIPTION
## Summary
- add a FastAPI application that exposes endpoints to list areas and compare store prices for their products
- provide an in-memory dataset and service layer that determines the cheapest store per product
- document usage and add pytest coverage for the aggregation logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd704338a0832bbbdd3a68b218cca4