### PR TITLE
Handle missing FastAPI dependency with clear message

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from fastapi import FastAPI, HTTPException
-from fastapi.responses import FileResponse
-from fastapi.staticfiles import StaticFiles
+try:
+    from fastapi import FastAPI, HTTPException
+    from fastapi.responses import FileResponse
+    from fastapi.staticfiles import StaticFiles
+except ModuleNotFoundError as exc:  # pragma: no cover - exercised when FastAPI is missing
+    raise ModuleNotFoundError(
+        "FastAPI is required to run this application. Install the dependencies with "
+        "`pip install -r requirements.txt` before starting the server."
+    ) from exc
 
 from .services import (
     AreaNotFoundError,


### PR DESCRIPTION
## Summary
- wrap FastAPI imports in a guarded try/except block
- raise an informative error instructing how to install the FastAPI dependency when it is missing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd793fd88c832baf265acd3c0e6344